### PR TITLE
Clean unused KVCache after usage

### DIFF
--- a/tests/under_models/send_mock_request.py
+++ b/tests/under_models/send_mock_request.py
@@ -42,6 +42,7 @@ class UglyAsyncLLMEngine(LLMEngine):
             blocks_to_swap_in={},
             blocks_to_swap_out={},
             blocks_to_copy={},
+            finished_seqs=[],
         )
         print(output)
 
@@ -68,6 +69,7 @@ class UglyAsyncLLMEngine(LLMEngine):
             blocks_to_swap_in={},
             blocks_to_swap_out={},
             blocks_to_copy={},
+            finished_seqs=[],
         )
 
         # TODO: change this to real one

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -200,7 +200,7 @@ class _AsyncLLMEngine(LLMEngine):
             blocks_to_swap_in=scheduler_outputs.blocks_to_swap_in,
             blocks_to_swap_out=scheduler_outputs.blocks_to_swap_out,
             blocks_to_copy=scheduler_outputs.blocks_to_copy,
-            finished_seqs =[],
+            finished_seqs=scheduler_outputs.finished_seqs,
         )
         print("We finished model_execution")
         return self._process_model_outputs(output, scheduler_outputs) + ignored

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -192,12 +192,15 @@ class _AsyncLLMEngine(LLMEngine):
             return ignored
 
         # Execute the model.
+        # Co(gc): Now that we do not have page table support, we need to pass the
+        # list of sequences that have been finished so that we can clean the KVCache.
         output = await self._run_workers_async(
             "execute_model",
             seq_group_metadata_list=seq_group_metadata_list,
             blocks_to_swap_in=scheduler_outputs.blocks_to_swap_in,
             blocks_to_swap_out=scheduler_outputs.blocks_to_swap_out,
             blocks_to_copy=scheduler_outputs.blocks_to_copy,
+            finished_seqs =[],
         )
         print("We finished model_execution")
         return self._process_model_outputs(output, scheduler_outputs) + ignored

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -384,8 +384,7 @@ class LLMEngine:
                 # not be used in the future iterations.
                 parent.status = SequenceStatus.FINISHED_ABORTED
                 seq_group.remove(parent.seq_id)
-                # TODO(gc): Should we do anything special in this case?
-                # self.scheduler.free_seq(parent)
+                self.scheduler.free_seq(parent)
                 continue
             # Fork the parent sequence if there are multiple child samples.
             # The outputs diverges, we need to fork the requests
@@ -425,7 +424,7 @@ class LLMEngine:
             # old sequences.
             for seq, parent in child_seqs:
                 if seq is parent and seq.is_finished():
-                    #self.scheduler.free_seq(seq)
+                    self.scheduler.free_seq(seq)
                     pass
             return
 
@@ -523,8 +522,7 @@ class LLMEngine:
         # manager. Keep them in the sequence group as candidate output.
         for seq, parent in selected_child_seqs:
             if seq is parent and seq.is_finished():
-                #self.scheduler.free_seq(seq)
-                pass
+                self.scheduler.free_seq(seq)
 
         # Remove the unselected parent sequences from the sequence group and
         # free their memory in block manager.
@@ -533,7 +531,7 @@ class LLMEngine:
                 # Remove the parent sequence if it is not selected for next
                 # iteration
                 seq_group.remove(seq.seq_id)
-                #self.scheduler.free_seq(seq)
+                self.scheduler.free_seq(seq)
 
     def _process_model_outputs(
             self, output: SamplerOutput,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -50,6 +50,21 @@ class Worker:
 
         self.kv_cache = dict()
 
+    def clean_finished_seqs(
+            self,
+            finished_seqs: List[int]
+        ):
+        """
+        This function cleans the finished sequences and their KVCache in self.kv_cache
+        """
+        for seq_id in finished_seqs:
+            if seq_id not in self.kv_cache.keys():
+                raise ValueError(
+                    f"Duplicate key {seq_id} received during clean worker's KVCache"
+                )
+            del self.kv_cache[seq_id]
+
+
     def init_model(self):
         # This env var set by Ray causes exceptions with graph building.
         os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
@@ -293,6 +308,7 @@ class Worker:
         blocks_to_swap_in: Dict[int, int],
         blocks_to_swap_out: Dict[int, int],
         blocks_to_copy: Dict[int, List[int]],
+        finished_seqs: List[int],
     ) -> SamplerOutput:
         # Issue cache operations.
         # issued_cache_op = False

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -326,6 +326,9 @@ class Worker:
         #     cache_events = self.cache_events
         # else:
         #     cache_events = None
+        if finished_seqs:
+            self.clean_finished_seqs(finished_seqs)
+
         cache_events = None
         # If there is no input, we don't need to execute the model.
         if not seq_group_metadata_list:


### PR DESCRIPTION
This will probably leave the last round KVCache in the dict.  However, this won't have bad behaviors as the KVCache will be cleaned at the beginning of the "model_execution"