### PR TITLE
[ADD] warning for vllm api_server

### DIFF
--- a/vllm/entrypoints/api_server.py
+++ b/vllm/entrypoints/api_server.py
@@ -131,6 +131,9 @@ async def run_server(args: Namespace,
 
 
 if __name__ == "__main__":
+    logger.warning("Warning: Please use `ipex_llm.vllm.xpu.entrypoints.openai.api_server` "
+                   "instead of `vllm.entrypoints.openai.api_server` to start the API server")
+
     parser = FlexibleArgumentParser()
     parser.add_argument("--host", type=str, default=None)
     parser.add_argument("--port", type=int, default=8000)

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -362,6 +362,9 @@ async def run_server(args, **uvicorn_kwargs) -> None:
 if __name__ == "__main__":
     # NOTE(simon):
     # This section should be in sync with vllm/scripts.py for CLI entrypoints.
+    logger.warning("Warning: Please use `ipex_llm.vllm.xpu.entrypoints.openai.api_server` "
+                   "instead of `vllm.entrypoints.openai.api_server` to start the API server")
+
     parser = FlexibleArgumentParser(
         description="vLLM OpenAI-Compatible RESTful API server.")
     parser = make_arg_parser(parser)


### PR DESCRIPTION
### Description
When users using api server from vllm instead of ipex_llm, add warning to notice them using `ipex_llm.vllm.xpu.entrypoints.openai.api_server`

### Test Result
![image](https://github.com/user-attachments/assets/db76b20b-59d5-4ec8-b5c0-9bdfb9b82b6b)

