### PR TITLE
Calculate max_input_len

### DIFF
--- a/vllm/worker/xpu_worker.py
+++ b/vllm/worker/xpu_worker.py
@@ -157,7 +157,7 @@ class XPUWorker(LoraNotSupportedWorkerBase, Worker):
 
         gc.collect()
         torch.xpu.empty_cache()
-        flag = int(os.getenv("TEST_INPUT", None))
+        flag = os.getenv("TEST_INPUT", None)
         if flag is not None:
             in_len = int(self.scheduler_config.max_num_batched_tokens / 1024)
             logger.info(f"before_memory {before_memory/(1024**3)} GB")

--- a/vllm/worker/xpu_worker.py
+++ b/vllm/worker/xpu_worker.py
@@ -157,7 +157,7 @@ class XPUWorker(LoraNotSupportedWorkerBase, Worker):
 
         gc.collect()
         torch.xpu.empty_cache()
-        flag = os.getenv("TEST_INPUT", None)
+        flag = os.getenv("IPEX_LLM_MAX_INPUT_LENGTH_DETAIL", None)
         if flag is not None:
             in_len = int(self.scheduler_config.max_num_batched_tokens / 1024)
             logger.info(f"before_memory {before_memory/(1024**3)} GB")
@@ -168,8 +168,9 @@ class XPUWorker(LoraNotSupportedWorkerBase, Worker):
             total_add_memory = total_gpu_memory*self.cache_config.gpu_memory_utilization-before_memory
             max_input = total_add_memory / (1024/self.cache_config.block_size*cache_block_size + add_memory/in_len)
             logger.info(f"total_add_memory {total_add_memory} B")
-            logger.info(f"guess max_input {max_input} K")
-            logger.info(f"actually input_len = {num_gpu_blocks*self.cache_config.block_size/1024} K")
+            logger.info(f"max-num-batched-tokens {in_len} K")
+            logger.info(f"theoretical max input length {max_input} K")
+            logger.info(f"num_gpu_blocks actually support max input length {num_gpu_blocks*self.cache_config.block_size/1024} K")
         return num_gpu_blocks, num_cpu_blocks
 
     def _warm_up_model(self) -> None:

--- a/vllm/worker/xpu_worker.py
+++ b/vllm/worker/xpu_worker.py
@@ -166,10 +166,10 @@ class XPUWorker(LoraNotSupportedWorkerBase, Worker):
             add_memory = peak_memory-before_memory
             logger.info(f"add_memory {add_memory} B")
             total_add_memory = total_gpu_memory*self.cache_config.gpu_memory_utilization-before_memory
-            max_input = total_add_memory / (64 * cache_block_size + add_memory/in_len)
+            max_input = total_add_memory / (1024/self.cache_config.block_size*cache_block_size + add_memory/in_len)
             logger.info(f"total_add_memory {total_add_memory} B")
             logger.info(f"guess max_input {max_input} K")
-            logger.info(f"actually input_len = {num_gpu_blocks*16/1024} K")
+            logger.info(f"actually input_len = {num_gpu_blocks*self.cache_config.block_size/1024} K")
         return num_gpu_blocks, num_cpu_blocks
 
     def _warm_up_model(self) -> None:


### PR DESCRIPTION
export IPEX_LLM_MAX_INPUT_LENGTH_DETAIL = true to calculate max_input_len
```
INFO 09-27 14:26:52 xpu_worker.py:181] before_memory 2.833984375 GB
INFO 09-27 14:26:52 xpu_worker.py:182] total_gpu_memory = 15.11093521118164 GB
INFO 09-27 14:26:52 xpu_worker.py:183] peak_memory 12.009765625 GB
INFO 09-27 14:26:52 xpu_worker.py:185] add_memory 9852420096 B
INFO 09-27 14:26:52 xpu_worker.py:188] total_add_memory 12371013427.199999 B
INFO 09-27 14:26:52 xpu_worker.py:189] guess max_input 113.5585072726882 K
INFO 09-27 14:26:52 xpu_worker.py:190] actually input_len = 120.09375 K
```