### PR TITLE
Fix awq and gptq error on vllm0.6.2

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -2,15 +2,16 @@ from typing import Tuple
 
 import torch
 
-from .interface import Platform, PlatformEnum
+from .interface import DeviceCapability, Platform, PlatformEnum
 
 
 class XpuPlatform(Platform):
     _enum = PlatformEnum.XPU
 
-    @staticmethod
-    def get_device_capability(device_id: int = 0) -> Tuple[int, int]:
-        return (100, 9)
+    @classmethod
+    def get_device_capability(cls, device_id: int = 0) -> DeviceCapability:
+        major, minor = (100, 9)
+        return DeviceCapability(major=major, minor=minor)
 
     @staticmethod
     def inference_mode():


### PR DESCRIPTION
## Description
1. Fix xpu platform `get_device_capability` return value.
2. Remove the cuda acceleration code whose torch is gptq.

## Test 
### awq
* code:
```python
from vllm import SamplingParams
from ipex_llm.vllm.xpu.engine import IPEXLLMClass as LLM

# Sample prompts.
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

# Create an LLM.
llm = LLM(model="/llm/models/Llama-2-7B-Chat-AWQ/",
          device="xpu",
          dtype="float16",
          enforce_eager=True,
          quantization="AWQ",
          load_in_low_bit="asym_int4",
          tensor_parallel_size=1)
# Generate texts from the prompts. The output is a list of RequestOutput objects
# that contain the prompt, generated text, and other information.
outputs = llm.generate(prompts, sampling_params)
# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")


```
* result:
![image](https://github.com/user-attachments/assets/fa4e6a63-02b3-438d-90d3-67d5136bd6f2)

* ### gptq
* code:
```python
from vllm import SamplingParams
from ipex_llm.vllm.xpu.engine import IPEXLLMClass as LLM

# Sample prompts.
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]
# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.8, top_p=0.95)

# Create an LLM.
llm = LLM(model="/llm/models/Llama-2-7B-Chat-GPTQ/",
          quantization="GPTQ",
          load_in_low_bit="asym_int4",
          device="xpu",
          dtype="float16",
          enforce_eager=True,
          tensor_parallel_size=1)
# Generate texts from the prompts. The output is a list of RequestOutput objects
# that contain the prompt, generated text, and other information.
outputs = llm.generate(prompts, sampling_params)
# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")


```
* result:
![image](https://github.com/user-attachments/assets/85f4f9e1-7236-4dbd-a1e5-dd4e0596964b)
