### PR TITLE
Refine configuration for attention_xpu.cpp

### DIFF
--- a/csrc/xpu/attention_xpu.cpp
+++ b/csrc/xpu/attention_xpu.cpp
@@ -649,7 +649,7 @@ void paged_attention_v1_kernel(
                                                                             \
     cgh.parallel_for(                                                       \
         sycl::nd_range<3>(grid * block, block),                             \
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] { \
+        [=](sycl::nd_item<3> item_ct1) { \
           paged_attention_v1_kernel<                                        \
               sycl_t,                                                       \
               Q_Vec,                                                        \
@@ -678,7 +678,7 @@ void paged_attention_v1_kernel(
   });                                                                       \
   ::xpu::profiler_record("paged attn v1", event);
 
-template <typename T, int BLOCK_SIZE, int NUM_THREADS = 512>
+template <typename T, int BLOCK_SIZE, int NUM_THREADS = 128>
 void paged_attention_xpu_v1_impl_launcher(
     torch::Tensor& out,
     torch::Tensor& query,
@@ -1026,7 +1026,7 @@ void paged_attention_v2_kernel(
                                                                             \
     cgh.parallel_for(                                                       \
         sycl::nd_range<3>(grid * block, block),                             \
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] { \
+        [=](sycl::nd_item<3> item_ct1) { \
           vllm::paged_attention_v2_kernel<                                  \
               sycl_t,                                                       \
               Q_Vec,                                                        \
@@ -1072,7 +1072,7 @@ void paged_attention_v2_kernel(
                                                                             \
     cgh.parallel_for(                                                       \
         sycl::nd_range<3>(reduce_grid * block, block),                      \
-        [=](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] { \
+        [=](sycl::nd_item<3> item_ct1)  { \
           vllm::paged_attention_v2_reduce_kernel<                           \
               sycl_t,                                                       \
               HEAD_SIZE,                                                    \
@@ -1094,7 +1094,7 @@ void paged_attention_v2_kernel(
 template <
     typename T,
     int BLOCK_SIZE,
-    int NUM_THREADS = 512,
+    int NUM_THREADS = 256,
     int PARTITION_SIZE = 512>
 void paged_attention_v2_launcher(
     torch::Tensor& out,


### PR DESCRIPTION


vLLM | 2xARC770 | TP2 | Qwen2.5-14B-Instruct | FP8 | 1 | 30.52826 | 423.0261 | 31.9921 | 0.983465
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
  | 2.2.0-b7 |   |   |   | 2 | 56.4111 | 778.8015 | 33.99859 | 0.9812
  |   |   |   |   | 4 | 101.9503 | 1153.626 | 37.0522 | 0.968432
  |   |   |   |   | 6 | 136.486 | 1535.058 | 41.04005 | 0.963608
  |   |   |   |   | 8 | 162.062 | 1937.625 | 45.66564 | 0.968929
  |   |   |   |   | 10 | 206.3586 | 2326.798 | 43.99728 | 0.964007
  |   |   |   |   | 12 | 232.5044 | 2720.045 | 46.38537 | 0.967773
  |   |   |   |   | 14 | 254.09 | 3107.151 | 49.12045 | 0.962014
  |   |   |   |   | 16 | 274.5366 | 3492.905 | 51.55335 | 0.963794
  |   |   |   |   | 18 | 243.6606 | 3880.514 | 66.41701 | 0.972004
  |   |   |   |   | 20 | 259.8757 | 4263.002 | 68.76075 | 0.974224
  |   |   |   |   | 22 | 273.293 | 4652.212 | 71.54498 | 0.973799
  |   |   |   |   | 24 | 287.8988 | 5033.827 | 73.66682 | 0.975461


