### PR TITLE
Update profile_run usage

### DIFF
--- a/vllm/worker/xpu_model_runner.py
+++ b/vllm/worker/xpu_model_runner.py
@@ -789,6 +789,15 @@ class XPUModelRunnerBase(ModelRunnerBase[TModelInputForXPU]):
                 max_num_seqs = 1
 
         batch_size = 0
+        import os
+        self_max_num_batched_tokens = os.getenv("IPEX_LLM_SELF_MAX_NUM_BATCHED_TOKENS", None)
+        if self_max_num_batched_tokens is not None:
+            max_num_batched_tokens = int(self_max_num_batched_tokens)
+            self_max_num_seqs = os.getenv("IPEX_LLM_SELF_MAX_NUM_SEQS", None)
+            if self_max_num_seqs is not None:
+                max_num_seqs = int(self_max_num_seqs)
+            else:
+                max_num_seqs = 1
         for group_id in range(max_num_seqs):
             seq_len = (max_num_batched_tokens // max_num_seqs +
                        (group_id < max_num_batched_tokens % max_num_seqs))

--- a/vllm/worker/xpu_worker.py
+++ b/vllm/worker/xpu_worker.py
@@ -134,18 +134,18 @@ class XPUWorker(Worker):
         torch.xpu.empty_cache()
         flag = os.getenv("IPEX_LLM_MAX_INPUT_LENGTH_DETAIL", None)
         if flag is not None:
-            in_len = int(self.scheduler_config.max_num_batched_tokens / 1024)
-            logger.info(f"before_memory {before_memory/(1024**3)} GB")
-            logger.info(f"total_gpu_memory = {total_gpu_memory/(1024**3)} GB")
-            logger.info(f"peak_memory {peak_memory/(1024**3)} GB")
+            in_len = self.scheduler_config.max_num_batched_tokens / 1024
+            logger.info(f"model first init memory {before_memory/(1024**3)} GB")
+            logger.info(f"one card total_gpu_memory = {total_gpu_memory/(1024**3)} GB")
+            logger.info(f"after first_token running, peak_memory {peak_memory/(1024**3)} GB")
             add_memory = peak_memory-before_memory
-            logger.info(f"add_memory {add_memory} B")
             total_add_memory = total_gpu_memory*self.cache_config.gpu_memory_utilization-before_memory
             max_input = total_add_memory / (1024/self.cache_config.block_size*cache_block_size + add_memory/in_len)
-            logger.info(f"total_add_memory {total_add_memory} B")
-            logger.info(f"max-num-batched-tokens {in_len} K")
-            logger.info(f"theoretical max input length {max_input} K")
-            logger.info(f"num_gpu_blocks actually support max input length {num_gpu_blocks*self.cache_config.block_size/1024} K")
+            logger.info(f"total_add_memory {total_add_memory/(1024**3)} GB")
+            logger.info(f"input max-model-len(or max-num-batched-tokens) {in_len} K")
+            logger.info(f"Theoretical max input length A: {max_input} K")
+            logger.info(f"Actually support max input length on this num_gpu_blocks B:{num_gpu_blocks*self.cache_config.block_size/1024} K")
+            logger.info(f"We need to increase A and decrease B (B>A) so that they reach a close value.")
         return num_gpu_blocks, num_cpu_blocks
 
     def _warm_up_model(self) -> None:


### PR DESCRIPTION
Update profile_run usage
export IPEX_LLM_SELF_MAX_NUM_BATCHED_TOKENS=40000
export IPEX_LLM_SELF_MAX_NUM_SEQS=1
to enable process one req with 40000 first_token input.


How to get the [max_context_len](https://github.com/analytics-zoo/nano/issues/1893)
![image](https://github.com/user-attachments/assets/c802cac8-6c87-4d85-bcf9-9a7826bced54)

