### PR TITLE
Fix 0.6.6 models

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -95,6 +95,7 @@ _TEXT_GENERATION_MODELS = {
     "Starcoder2ForCausalLM": ("starcoder2", "Starcoder2ForCausalLM"),
     "SolarForCausalLM": ("solar", "SolarForCausalLM"),
     "TeleChat2ForCausalLM": ("telechat2", "TeleChat2ForCausalLM"),
+    "TeleChatForCausalLM": ("telechat2", "TeleChat2ForCausalLM"),
     "XverseForCausalLM": ("llama", "LlamaForCausalLM"),
     # [Encoder-decoder]
     "BartModel": ("bart", "BartForConditionalGeneration"),

--- a/vllm/model_executor/models/telechat2.py
+++ b/vllm/model_executor/models/telechat2.py
@@ -42,9 +42,9 @@ class TeleChat2Model(LlamaModel):
         for layer in self.layers:
             if not isinstance(layer, PPMissingLayer):
                 layer.self_attn.qkv_proj.bias = None
-                layer.self_attn.qkv_proj.skip_bias_add = True
+                #layer.self_attn.qkv_proj.skip_bias_add = True
                 layer.mlp.gate_up_proj.bias = None
-                layer.mlp.gate_up_proj.skip_bias_add = True
+                #layer.mlp.gate_up_proj.skip_bias_add = True
 
     def load_weights(self, weights: Iterable[Tuple[str,
                                                    torch.Tensor]]) -> Set[str]:


### PR DESCRIPTION
1. find the reason why minicpmv-2_6 fail.
Compared to [transformers_4.48](https://github.com/huggingface/transformers/blob/v4.48.0/src/transformers/image_transforms.py#L396) and [transformers_4.49](https://github.com/huggingface/transformers/blob/v4.49.0/src/transformers/image_transforms.py#L428), The structure of `mean` has changed. Need to use `pip install tranformers==4.48.0` to run minicpmv-2_6.
2. Fix TeleChat2-35B error.
3. Optimize glm4v-9b vision self_attention.
