### PR TITLE
Use ipex.varlen_attn for prefill in 0.6.6

### DIFF
--- a/vllm/_ipex_ops.py
+++ b/vllm/_ipex_ops.py
@@ -6,10 +6,10 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
-try:
-    import intel_extension_for_pytorch as ipex
-except ImportError as e:
-    logger.warning("Import error msg: %s", e.msg)
+# try:
+#     import intel_extension_for_pytorch as ipex
+# except ImportError as e:
+#     logger.warning("Import error msg: %s", e.msg)
 
 import vllm._C.ops
 
@@ -229,13 +229,16 @@ class ipex_ops:
         gen_: torch.Generator,
         logits_soft_cap: float,
     ) -> None:
-        pass
-
-        # ipex.llm.functional.varlen_attention(query, key, value, out, seqlen_q,
-        #                                      seqlen_k, max_seqlen_q,
-        #                                      max_seqlen_k, pdropout,
-        #                                      softmax_scale, zero_tensors,
-        #                                      is_causal, return_softmax, gen_)
+        import intel_extension_for_pytorch as ipex
+        ipex.llm.functional.varlen_attention(query.contiguous(),
+                                             key.contiguous(),
+                                             value.contiguous(), out,
+                                             seqlen_q.int(), seqlen_k.int(),
+                                             max_seqlen_q, max_seqlen_k,
+                                             pdropout, softmax_scale,
+                                             zero_tensors, is_causal,
+                                             return_softmax, gen_,
+                                             logits_soft_cap)
 
     @staticmethod
     def reshape_and_cache(

--- a/vllm/attention/backends/ipex_attn.py
+++ b/vllm/attention/backends/ipex_attn.py
@@ -410,70 +410,78 @@ class IpexAttnBackendImpl(AttentionImpl[IpexAttnMetadata]):
                         att_masks = [None] * len(prefill_meta.seq_lens)
                     prefill_meta.attn_bias = att_masks
 
-                # output = torch.empty(
-                #     (num_tokens, self.num_heads, self.head_size),
-                #     dtype=query.dtype,
-                #     device=query.device)
-                # ipex_ops.varlen_attention(query,
-                #                           key,
-                #                           value,
-                #                           output,
-                #                           attn_metadata.seqlen_q,
-                #                           attn_metadata.seqlen_q,
-                #                           attn_metadata.max_seqlen,
-                #                           attn_metadata.max_seqlen,
-                #                           pdropout=0.0,
-                #                           softmax_scale=self.scale,
-                #                           zero_tensors=False,
-                #                           is_causal=True,
-                #                           return_softmax=False,
-                #                           gen_=None)
-
-                output = torch.empty(
-                            (num_tokens, self.num_heads, self.head_size),
-                            dtype=query.dtype, device=query.device)
-                query = query.movedim(0, query.dim() - 2)
-                key = key.movedim(0, key.dim() - 2)
-                value = value.movedim(0, value.dim() - 2)
-                import math
-                scale = 1 / math.sqrt(self.head_size) if self.scale is None else self.scale
-                start = 0
-                for seq_len, mask in zip(prefill_meta.seq_lens,
-                                        prefill_meta.attn_bias):
-                    end = start + seq_len
-                    if self.alibi_slopes is None and use_sdp_causal(self.head_size, query, self.logits_soft_cap):
-                        import xe_addons
-                        if mask is not None:
-                            mask = mask.unsqueeze(0)
-                        if self.logits_soft_cap == 0 or self.head_size != 256:
-                            sub_out = xe_addons.sdp_causal(
-                                query[None, :, start:end, :].contiguous(),
-                                key[None, :, start:end, :].contiguous(),
-                                value[None, :, start:end, :].contiguous(),
-                                mask,
-                                scale).squeeze(0).movedim(
-                                    query.dim() - 2, 0)
+                flag = os.getenv("IPEX_LLM_PREFILL_VARLEN_BACKEND", None)
+                if flag is not None:
+                    output = torch.empty(
+                        (num_tokens, self.num_heads, self.head_size),
+                        dtype=query.dtype,
+                        device=query.device)
+                        
+                    tmp = [0]
+                    tmp.extend(prefill_meta.seq_lens)
+                    seqlen = torch.tensor(tmp)
+                    seqlen_q = torch.cumsum(seqlen, dim=0).to(device=query.device)
+                    ipex_ops.varlen_attention(query,
+                                              key,
+                                              value,
+                                              output,
+                                              seqlen_q,
+                                              seqlen_q,
+                                              prefill_meta.max_seqlen,
+                                              prefill_meta.max_seqlen,
+                                              pdropout=0.0,
+                                              softmax_scale=self.scale,
+                                              zero_tensors=False,
+                                              is_causal=True,
+                                              return_softmax=False,
+                                              gen_=None,
+                                              logits_soft_cap=self.logits_soft_cap)
+                else:                                          
+                    output = torch.empty(
+                                (num_tokens, self.num_heads, self.head_size),
+                                dtype=query.dtype, device=query.device)
+                    query = query.movedim(0, query.dim() - 2)
+                    key = key.movedim(0, key.dim() - 2)
+                    value = value.movedim(0, value.dim() - 2)
+                    import math
+                    scale = 1 / math.sqrt(self.head_size) if self.scale is None else self.scale
+                    start = 0
+                    for seq_len, mask in zip(prefill_meta.seq_lens,
+                                            prefill_meta.attn_bias):
+                        end = start + seq_len
+                        if self.alibi_slopes is None and use_sdp_causal(self.head_size, query, self.logits_soft_cap):
+                            import xe_addons
+                            if mask is not None:
+                                mask = mask.unsqueeze(0)
+                            if self.logits_soft_cap == 0 or self.head_size != 256:
+                                sub_out = xe_addons.sdp_causal(
+                                    query[None, :, start:end, :].contiguous(),
+                                    key[None, :, start:end, :].contiguous(),
+                                    value[None, :, start:end, :].contiguous(),
+                                    mask,
+                                    scale).squeeze(0).movedim(
+                                        query.dim() - 2, 0)
+                            else:
+                                sub_out = xe_addons.gemma2_sdp_causal(
+                                    query[None, :, start:end, :].contiguous(),
+                                    key[None, :, start:end, :].contiguous(),
+                                    value[None, :, start:end, :].contiguous(),
+                                    mask,
+                                    self.logits_soft_cap,
+                                    self.scale).squeeze(0).movedim(
+                                        query.dim() - 2, 0)                            
                         else:
-                            sub_out = xe_addons.gemma2_sdp_causal(
-                                query[None, :, start:end, :].contiguous(),
-                                key[None, :, start:end, :].contiguous(),
-                                value[None, :, start:end, :].contiguous(),
-                                mask,
-                                self.logits_soft_cap,
-                                self.scale).squeeze(0).movedim(
-                                    query.dim() - 2, 0)                            
-                    else:
-                        sub_out = torch.nn.functional.scaled_dot_product_attention(
-                            query[None, :, start:end, :],
-                            key[None, :, start:end, :],
-                            value[None, :, start:end, :],
-                            attn_mask=mask,
-                            dropout_p=0.0,
-                            is_causal=not self.need_mask,
-                            scale=self.scale).squeeze(0).movedim(
-                                query.dim() - 2, 0)
-                    output[start:end, :, :] = sub_out
-                    start = end
+                            sub_out = torch.nn.functional.scaled_dot_product_attention(
+                                query[None, :, start:end, :],
+                                key[None, :, start:end, :],
+                                value[None, :, start:end, :],
+                                attn_mask=mask,
+                                dropout_p=0.0,
+                                is_causal=not self.need_mask,
+                                scale=self.scale).squeeze(0).movedim(
+                                    query.dim() - 2, 0)
+                        output[start:end, :, :] = sub_out
+                        start = end
             else:
                 # prefix-enabled attention
                 if self.num_kv_heads != self.num_heads:

--- a/vllm/attention/backends/ipex_attn.py
+++ b/vllm/attention/backends/ipex_attn.py
@@ -412,6 +412,7 @@ class IpexAttnBackendImpl(AttentionImpl[IpexAttnMetadata]):
 
                 flag = os.getenv("IPEX_LLM_PREFILL_VARLEN_BACKEND", None)
                 if flag is not None:
+                    logger.info(f"Using varlen_attention for prefilling.")
                     output = torch.empty(
                         (num_tokens, self.num_heads, self.head_size),
                         dtype=query.dtype,

--- a/vllm/attention/backends/ipex_attn.py
+++ b/vllm/attention/backends/ipex_attn.py
@@ -12,6 +12,10 @@ from vllm.attention.backends.utils import CommonAttentionState
 from vllm.attention.ops.paged_attn import (PagedAttention,
                                            PagedAttentionMetadata)
 
+from vllm.logger import init_logger
+logger = init_logger('vllm.attention.backends.ipex_attn')
+from vllm.utils import print_info_once, print_warning_once
+
 _PARTITION_SIZE = 512
 
 
@@ -268,6 +272,12 @@ class IpexAttnBackendImpl(AttentionImpl[IpexAttnMetadata]):
             raise NotImplementedError(
                 "IPEX backend does not support FP8 KV cache. "
                 "Please use xFormers backend instead.")
+        
+        self.ipex_varlen_attn = False
+        flag = os.getenv("IPEX_LLM_PREFILL_VARLEN_BACKEND", None)
+        if flag is not None:
+            self.ipex_varlen_attn = True
+            print_info_once(f"Using varlen_attention for prefilling.")
 
     def split_kv_cache(
         self,
@@ -410,9 +420,8 @@ class IpexAttnBackendImpl(AttentionImpl[IpexAttnMetadata]):
                         att_masks = [None] * len(prefill_meta.seq_lens)
                     prefill_meta.attn_bias = att_masks
 
-                flag = os.getenv("IPEX_LLM_PREFILL_VARLEN_BACKEND", None)
-                if flag is not None:
-                    logger.info(f"Using varlen_attention for prefilling.")
+                
+                if self.ipex_varlen_attn:
                     output = torch.empty(
                         (num_tokens, self.num_heads, self.head_size),
                         dtype=query.dtype,

--- a/vllm/attention/ops/ipex_attn.py
+++ b/vllm/attention/ops/ipex_attn.py
@@ -1,10 +1,11 @@
 from typing import Dict, List, Optional, Tuple
 
-try:
-    import intel_extension_for_pytorch.llm.modules as ipex_modules
-    _use_ipex = True
-except ImportError:
-    _use_ipex = False
+# try:
+#     import intel_extension_for_pytorch.llm.modules as ipex_modules
+#     _use_ipex = True
+# except ImportError:
+#     _use_ipex = False
+_use_ipex = False
 
 import torch
 


### PR DESCRIPTION
Install extra dependencies:
```
pip install intel-extension-for-pytorch==2.6.10+xpu \
    --extra-index-url=https://pytorch-extension.intel.com/release-whl/stable/xpu/us/

pip uninstall -y oneccl oneccl-devel
pip install -r requirements-xpu.txt
pip install intel-opencl-rt==2025.0.2 intel-openmp==2025.0.2
```

Setting extra env:
```
export IPEX_LLM_PREFILL_VARLEN_BACKEND=1
```

A long input test result is listed below: (`export IPEX_LLM_SELF_MAX_NUM_BATCHED_TOKENS=40000
export IPEX_LLM_SELF_MAX_NUM_SEQS=1`)
![image](https://github.com/user-attachments/assets/5f820082-e8e4-4563-957c-2d5be8541d2d)
